### PR TITLE
Fix git address in example pre-commit yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ imports for you (or show you how it should be done).
 
 Add this to your ``.pre-commit-config.yaml`` file
 
-    - repo: git@github.com:FalconSocial/pre-commit-python-sorter.git
+    - repo: git://github.com/FalconSocial/pre-commit-python-sorter
       sha: 1.0.1
       hooks:
       - id: python-import-sorter


### PR DESCRIPTION
The git@ syntax requires an SSH key with permissions to the repo.

I was getting this error using the example:

```
$ pre-commit autoupdate
Updating git://github.com/pre-commit/pre-commit-hooks...already up to date.
Updating git@github.com:FalconSocial/pre-commit-python-sorter.git...An unexpected error has occurred: CalledProcessError: Command: (u'git', u'clone', u'--no-checkout', 'git@github.com:FalconSocial/pre-commit-python-sorter.git', u'/home/sdet/.pre-commit/repom4RjDu')
Return code: 128
Expected return code: 0
Output: (u"Cloning into '/home/sdet/.pre-commit/repom4RjDu'...\n", u'Permission denied (publickey).\r\nfatal: The remote end hung up unexpectedly\n')
```

After this change:

```
$ pre-commit autoupdate
Updating git://github.com/pre-commit/pre-commit-hooks...already up to date.
Updating git://github.com/FalconSocial/pre-commit-python-sorter...updating 1.0.1 -> 31865d04ebd9961fb5fd4fb57ec4016c1db0bbe4.
```
