### PR TITLE
Allow for passing the force_single_line argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Available flags:
 * ``--silent-overwrite``: The hook won't fail if it has to change files. It will
     just do it.
 
+* ``--force_single_line``: Force each import onto a single line.
+
 The hook supports [isort's configuration files](https://github.com/timothycrosley/isort#configuring-isort) - Please refer to the isort documentation for reference
 
 Development: ``pip install -r requirements-dev.txt``

--- a/pre_commit_hook/sort.py
+++ b/pre_commit_hook/sort.py
@@ -12,7 +12,8 @@ def main(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*', help='Filenames to run')
     parser.add_argument('--silent-overwrite', action='store_true', dest='silent')
-    parser.set_defaults(silent=False)
+    parser.add_argument('--force_single_line', action='store_true', dest='force_single_line')
+    parser.set_defaults(silent=False, force_single_line=False)
     args = parser.parse_args(argv)
 
     return_value = 0
@@ -21,10 +22,10 @@ def main(argv=None):
         if imports_incorrect(filename) is True:
             if args.silent is False:
                 return_value =  1
-                isort.SortImports(filename)
+                isort.SortImports(filename, force_single_line=args.force_single_line)
                 print('FIXED: {0}'.format(os.path.abspath(filename)))
             else:
-                isort.SortImports(filename)
+                isort.SortImports(filename, force_single_line=args.force_single_line)
     return return_value
 
 if __name__ == '__main__':

--- a/tests/sort_test.py
+++ b/tests/sort_test.py
@@ -19,3 +19,4 @@ def test_sort(tmpfiles):
     assert main([tmpfiles.join('correct_1.py').strpath]) == 0
     assert main([tmpfiles.join('incorrect_1.py').strpath]) == 1
     assert main([tmpfiles.join('incorrect_2.py').strpath, '--silent-overwrite']) == 0
+    assert main([tmpfiles.join('incorrect_2.py').strpath, '--force_single_line']) == 0


### PR DESCRIPTION
The style guide for the project I work on dictates one import per line.
isort supports this with the force_single_line option.
I've simply plumbed that from the pre-commit options through to the invocation of isort.
