### PR TITLE
Add --check-only command line flag

### DIFF
--- a/pre_commit_hook/sort.py
+++ b/pre_commit_hook/sort.py
@@ -1,30 +1,35 @@
 from __future__ import print_function
+
 import argparse
 import os
 
 from isort import isort
 
 
+def imports_incorrect(filename):
+    return isort.SortImports(filename, check=True).incorrectly_sorted
+
+
 def main(argv=None):
-    def imports_incorrect(filename):
-        return isort.SortImports(filename, check=True).incorrectly_sorted
 
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*', help='Filenames to run')
-    parser.add_argument('--silent-overwrite', action='store_true', dest='silent')
-    parser.set_defaults(silent=False)
+    parser.add_argument('--silent-overwrite', action='store_true', dest='silent', default=False)
+    parser.add_argument('--check-only', action='store_true', dest='check_only', default=False)
     args = parser.parse_args(argv)
 
     return_value = 0
 
     for filename in args.filenames:
-        if imports_incorrect(filename) is True:
-            if args.silent is False:
-                return_value =  1
+        if imports_incorrect(filename):
+            if args.check_only:
+                return_value = 1
+            elif args.silent:
+                isort.SortImports(filename)
+            else:
+                return_value = 1
                 isort.SortImports(filename)
                 print('FIXED: {0}'.format(os.path.abspath(filename)))
-            else:
-                isort.SortImports(filename)
     return return_value
 
 if __name__ == '__main__':

--- a/tests/sort_test.py
+++ b/tests/sort_test.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 
 from pre_commit_hook.sort import main
@@ -8,6 +7,7 @@ def write_file(filename, contents):
     with open(filename, 'w') as file_obj:
         file_obj.write(contents)
 
+
 @pytest.fixture
 def tmpfiles(tmpdir):
     write_file(tmpdir.join('correct_1.py').strpath, 'import json\nimport sys\n')
@@ -15,7 +15,9 @@ def tmpfiles(tmpdir):
     write_file(tmpdir.join('incorrect_2.py').strpath, 'import sys\n\n\nimport json\n')
     return tmpdir
 
+
 def test_sort(tmpfiles):    
     assert main([tmpfiles.join('correct_1.py').strpath]) == 0
     assert main([tmpfiles.join('incorrect_1.py').strpath]) == 1
+    assert main([tmpfiles.join('incorrect_2.py').strpath, '--check-only']) == 1
     assert main([tmpfiles.join('incorrect_2.py').strpath, '--silent-overwrite']) == 0


### PR DESCRIPTION
Add a `--check-only` command line flag that only aborts but doesn't auto-fix files. We're using this to slowly migrate our codebase as we go, deciding for every conflicting file whether it can be auto-sorted or needs to be exempt.