### PR TITLE
Add --diff flag to show diff of expected imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Available flags:
 
 * ``--silent-overwrite``: The hook won't fail if it has to change files. It will
     just do it.
+* ``--check-only``: The hook will not change any files.
+* ``--diff``: If imports are not ordered correctly, print a diff of required
+    changes to fix the import order.
 
 The hook supports [isort's configuration files](https://github.com/timothycrosley/isort#configuring-isort) - Please refer to the isort documentation for reference
 

--- a/pre_commit_hook/sort.py
+++ b/pre_commit_hook/sort.py
@@ -6,8 +6,8 @@ import os
 from isort import isort
 
 
-def imports_incorrect(filename):
-    return isort.SortImports(filename, check=True).incorrectly_sorted
+def imports_incorrect(filename, show_diff=False):
+    return isort.SortImports(filename, check=True, show_diff=show_diff).incorrectly_sorted
 
 
 def main(argv=None):
@@ -16,12 +16,13 @@ def main(argv=None):
     parser.add_argument('filenames', nargs='*', help='Filenames to run')
     parser.add_argument('--silent-overwrite', action='store_true', dest='silent', default=False)
     parser.add_argument('--check-only', action='store_true', dest='check_only', default=False)
+    parser.add_argument('--diff', action='store_true', dest='show_diff', default=False)
     args = parser.parse_args(argv)
 
     return_value = 0
 
     for filename in args.filenames:
-        if imports_incorrect(filename):
+        if imports_incorrect(filename, show_diff=args.show_diff):
             if args.check_only:
                 return_value = 1
             elif args.silent:

--- a/tests/sort_test.py
+++ b/tests/sort_test.py
@@ -1,4 +1,5 @@
 import pytest
+from isort.isort import stdout
 
 from pre_commit_hook.sort import main
 
@@ -21,3 +22,20 @@ def test_sort(tmpfiles):
     assert main([tmpfiles.join('incorrect_1.py').strpath]) == 1
     assert main([tmpfiles.join('incorrect_2.py').strpath, '--check-only']) == 1
     assert main([tmpfiles.join('incorrect_2.py').strpath, '--silent-overwrite']) == 0
+
+
+def test_sort_with_diff(tmpfiles):
+    filename = tmpfiles.join('incorrect_1.py').strpath
+    main(['--diff', '--check-only', filename])
+
+    stdout.seek(0)
+    lines = stdout.read().splitlines()
+    # Skip diff header
+    lines = lines[4:]
+    assert lines == [
+        '+import json',
+        ' import sys',
+        '-',
+        '-',
+        '-import json',
+    ]


### PR DESCRIPTION
Add `--diff` flag that is passed along to `isort`. This is very helpful in debugging, when trying to figure out why the pre-commit hook fails on a file that I already ran `isort` on. (Spoiler: `isort` runs in its own virtual environment, which breaks its inferring of third-party packages. I'll submit a new PR to add a flag for the virtual env once my `isort` PR is merged.)