### PR TITLE
Fix #16 -- add .pre-commit-hooks.yaml for pre-commit update

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: python-import-sorter
+  name: Sort python imports
+  description: This hook sorts python imports.
+  entry: python-import-sorter
+  language: python
+  files: \.py$


### PR DESCRIPTION
Greetings, @FalconSocial peeps!

As mentioned here: https://github.com/FalconSocial/pre-commit-python-sorter/issues/16
We need to add `.pre-commit-hooks.yaml` for newer pre-commit versions.
And it would be good to leave old `hooks.yaml` for some time.

Thanks for the package.